### PR TITLE
Fix CUE-files parsing for very long records

### DIFF
--- a/audiotools/cue.py
+++ b/audiotools/cue.py
@@ -64,7 +64,7 @@ def tokens(cuedata):
     #between tokens aren't enforced.
     TOKENS = [(re.compile("^(%s)" % (s)), element) for (s, element) in
               [(r'[A-Z]{2}[A-Za-z0-9]{3}[0-9]{7}', ISRC),
-               (r'[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}', TIMESTAMP),
+               (r'[0-9]{1,3}:[0-9]{1,2}:[0-9]{1,2}', TIMESTAMP),
                (r'[0-9]+', NUMBER),
                (r'[\r\n]+', EOL),
                (r'".+?"', STRING),


### PR DESCRIPTION
Some records are longer than 100 minutes so they could contain CUE-track entries
with 3-digits "INDEX 01" value.

...
  TRACK 23 AUDIO
    TITLE "Pick Up The Virus"
    PERFORMER "Aural Float"
    INDEX 01 93:08:50
  TRACK 24 AUDIO
    TITLE "Alone"
    PERFORMER "Jaia"
    INDEX 01 101:06:65
  TRACK 25 AUDIO
    TITLE "Life Lines"
    PERFORMER "Astropilot"
    INDEX 01 105:51:69
...

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>python-audio-tools